### PR TITLE
Migrate to @11ty/eleventy-plugin-rss v3

### DIFF
--- a/_11ty/plugins.js
+++ b/_11ty/plugins.js
@@ -1,6 +1,6 @@
 const { IS_PRODUCTION } = require('./constants');
 const siteConfig = require('../content/_data/siteConfig');
-const pluginRss = require('@11ty/eleventy-plugin-rss');
+const { rssPlugin } = require('@11ty/eleventy-plugin-rss');
 const { EleventyHtmlBasePlugin } = require('@11ty/eleventy');
 const pluginEmoji = require('eleventy-plugin-emoji');
 const eleventyNavigationPlugin = require('@11ty/eleventy-navigation');
@@ -41,7 +41,7 @@ const plugins = [
     body: EleventyHtmlBasePlugin,
   },
   {
-    body: pluginRss,
+    body: rssPlugin,
   },
   {
     body: pluginEmoji,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@11ty/eleventy": "^3.1.2",
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-navigation": "^1.0.5",
-        "@11ty/eleventy-plugin-rss": "^2.0.4",
+        "@11ty/eleventy-plugin-rss": "^3.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "cheerio": "^1.2.0",
         "crypto-js": "^4.2.0",
@@ -620,15 +620,15 @@
       }
     },
     "node_modules/@11ty/eleventy-plugin-rss": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-2.0.4.tgz",
-      "integrity": "sha512-LF60sGVlxGTryQe3hTifuzrwF8R7XbrNsM2xfcDcNMSliLN4kmB+7zvoLRySRx0AQDjqhPTAeeeT0ra6/9zHUQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-3.0.0.tgz",
+      "integrity": "sha512-kKW4DcR57xAyRx0e8gNhKh56ahHVEaAj8/TuXQDnw+B46ig2bWADJAlyj/GdV37IG5ja9dZ4SgKZrs/CHz6YWQ==",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy-utils": "^2.0.0",
-        "@11ty/posthtml-urls": "^1.0.1",
-        "debug": "^4.4.0",
-        "posthtml": "^0.16.6"
+        "@11ty/eleventy-utils": "^2.0.7",
+        "@11ty/posthtml-urls": "^1.0.2",
+        "debug": "^4.4.3",
+        "posthtml": "^0.16.7"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@11ty/eleventy": "^3.1.2",
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-navigation": "^1.0.5",
-    "@11ty/eleventy-plugin-rss": "^2.0.4",
+    "@11ty/eleventy-plugin-rss": "^3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "cheerio": "^1.2.0",
     "crypto-js": "^4.2.0",


### PR DESCRIPTION
Completes the dependency update held back in #20.

**The breaking change:** v3 is ESM-only and moved the legacy filters plugin from the default export to a named `rssPlugin` export. So `require('@11ty/eleventy-plugin-rss')` now returns an object, which is why `addPlugin` rejected it.

**The fix:** import the named `{ rssPlugin }` export. That's the whole migration — the custom feed templates and the filters they rely on (`htmlToAbsoluteUrls`, `dateToRfc3339`/`822`, `getNewestCollectionItemDate`) are unchanged and still registered under the same names. The removed `rssDate`/`rssLastUpdatedDate` filters weren't used here.

**Verified:** all three feeds build with 10 entries each, absolute URLs resolve correctly, and both XML feeds pass `xmllint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)