### PR TITLE
Add stream-item workflow + Apple Shortcut setup

### DIFF
--- a/.github/workflows/add-stream-item.yml
+++ b/.github/workflows/add-stream-item.yml
@@ -1,0 +1,57 @@
+name: Add stream item
+
+# Triggered from the Apple Shortcut via the GitHub API (workflow_dispatch).
+# Fetches the page title, writes a reading/building post, and opens a draft PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: URL of the page to add
+        required: true
+      description:
+        description: Short take / description
+        required: false
+        default: ''
+      type:
+        description: reading or building
+        required: false
+        default: reading
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  add-item:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Create stream item
+        id: create
+        env:
+          URL: ${{ inputs.url }}
+          DESCRIPTION: ${{ inputs.description }}
+          TYPE: ${{ inputs.type }}
+        run: node scripts/new-stream-item.mjs
+
+      - name: Open draft PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ${{ steps.create.outputs.branch }}
+          draft: true
+          title: 'Add ${{ inputs.type }}: ${{ steps.create.outputs.title }}'
+          commit-message: 'Add ${{ inputs.type }} item: ${{ steps.create.outputs.title }}'
+          add-paths: content/posts/**
+          body: |
+            Auto-created from the Apple Shortcut.
+
+            - URL: ${{ inputs.url }}
+            - File: `${{ steps.create.outputs.path }}`
+
+            Edit the wording if you want, then mark it ready and merge.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,4 +51,10 @@ export default [
       semi: ['error', 'always'],
     },
   },
+  {
+    files: ['**/*.mjs'],
+    languageOptions: {
+      sourceType: 'module',
+    },
+  },
 ];

--- a/scripts/new-stream-item.mjs
+++ b/scripts/new-stream-item.mjs
@@ -1,0 +1,108 @@
+// Creates a new stream post (reading / building) from a URL + description.
+// The page title is fetched and parsed here so the Apple Shortcut only has to
+// send the URL and a short description.
+//
+// Inputs (env): URL (required), DESCRIPTION (optional), TYPE (default "reading")
+// On GitHub Actions it appends title/path/branch/slug to $GITHUB_OUTPUT.
+// Dependency-free: uses Node built-ins and global fetch (Node 18+).
+
+import { writeFile, mkdir, appendFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const url = (process.env.URL || '').trim();
+const description = (process.env.DESCRIPTION || '').trim();
+const type = (process.env.TYPE || 'reading').trim();
+
+if (!url) {
+  console.error('URL is required (set the URL env var).');
+  process.exit(1);
+}
+
+function decodeEntities(s) {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;|&#0*39;|&#x0*27;/gi, '\'')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)));
+}
+
+async function fetchTitle(target) {
+  try {
+    const res = await fetch(target, {
+      headers: { 'user-agent': 'Mozilla/5.0 (stream-item-bot)' },
+      redirect: 'follow',
+    });
+    const html = await res.text();
+    const og =
+      html.match(/<meta[^>]+property=["']og:title["'][^>]*content=["']([^"']+)["']/i) ||
+      html.match(/<meta[^>]+content=["']([^"']+)["'][^>]*property=["']og:title["']/i);
+    if (og) return decodeEntities(og[1]).trim();
+    const t = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+    if (t && t[1].trim()) return decodeEntities(t[1]).trim();
+  } catch (err) {
+    console.error('Could not fetch title:', err.message);
+  }
+  return url; // fall back to the URL itself
+}
+
+function slugify(s) {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60)
+      .replace(/-+$/g, '') || 'item'
+  );
+}
+
+function yamlQuote(s) {
+  return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+const title = await fetchTitle(url);
+
+const now = new Date();
+const yyyy = String(now.getFullYear());
+const mm = String(now.getMonth() + 1).padStart(2, '0');
+const dd = String(now.getDate()).padStart(2, '0');
+const dateStr = `${yyyy}-${mm}-${dd}`;
+
+const slug = slugify(title);
+const dir = path.join('content', 'posts', yyyy);
+const filepath = path.join(dir, `${mm}-${dd}-${slug}.md`);
+
+const tags = type === 'building' ? ['ai', 'building'] : ['ai', 'reading'];
+const tagLines = tags.map((t) => `  - ${t}`).join('\n');
+const body = description || `[${title}](${url})`;
+
+const content = `---
+title: ${yamlQuote(title)}
+description: ${yamlQuote(description || title)}
+date: ${dateStr}
+type: ${type}
+externalUrl: ${url}
+tags:
+${tagLines}
+---
+
+${body}
+`;
+
+await mkdir(dir, { recursive: true });
+await writeFile(filepath, content, 'utf8');
+
+console.log(`Created ${filepath}`);
+console.log(`Title: ${title}`);
+
+if (process.env.GITHUB_OUTPUT) {
+  const branch = `${type}-${dateStr}-${slug}`.slice(0, 80);
+  await appendFile(
+    process.env.GITHUB_OUTPUT,
+    `title=${title}\npath=${filepath}\nbranch=${branch}\nslug=${slug}\n`
+  );
+}

--- a/scripts/stream-item-shortcut.md
+++ b/scripts/stream-item-shortcut.md
@@ -1,0 +1,53 @@
+# Adding stream items from an Apple Shortcut
+
+The `Add stream item` GitHub Actions workflow (`.github/workflows/add-stream-item.yml`)
+takes a URL and a short description, fetches the page title, writes a `reading` (or
+`building`) post, and opens a **draft PR**. An Apple Shortcut triggers it via the GitHub API.
+
+## One-time setup
+
+### 1. Create a fine-grained personal access token
+
+GitHub → Settings → Developer settings → Fine-grained tokens → Generate new token.
+
+- Repository access: only `larryhudson/11ty-blog-bliss`
+- Permissions: **Actions → Read and write** (this is all it can do — trigger workflows)
+- Copy the token; you'll paste it into the Shortcut.
+
+### 2. Allow Actions to open PRs
+
+Repo → Settings → Actions → General → Workflow permissions →
+tick **"Allow GitHub Actions to create and approve pull requests"**.
+(The workflow's own `GITHUB_TOKEN` opens the PR; this setting lets it.)
+
+## The Shortcut
+
+Make a new Shortcut with these actions:
+
+1. **Receive** URLs from the share sheet (Shortcut settings → "Show in Share Sheet",
+   accept URLs). Or start with an **Ask for Input** (Text) for the URL.
+2. **Ask for Input** → Text → prompt "Description" (your short take).
+3. **Get Contents of URL**:
+   - URL: `https://api.github.com/repos/larryhudson/11ty-blog-bliss/actions/workflows/add-stream-item.yml/dispatches`
+   - Method: `POST`
+   - Headers:
+     - `Authorization`: `Bearer YOUR_TOKEN`
+     - `Accept`: `application/vnd.github+json`
+     - `X-GitHub-Api-Version`: `2022-11-28`
+   - Request Body: **JSON**
+     - `ref` (Text): `main`
+     - `inputs` (Dictionary):
+       - `url` (Text): the Shortcut Input / URL from step 1
+       - `description` (Text): the answer from step 2
+       - `type` (Text): `reading`
+4. (Optional) **Show Notification**: "Reading item submitted".
+
+A successful dispatch returns `204 No Content`. The workflow then runs and opens a draft
+PR within a minute or so.
+
+## Notes
+
+- For a "building" item (a repo), duplicate the Shortcut and set `type` to `building`.
+- The post body defaults to your description; edit the wording in the draft PR before merging.
+- Title is fetched server-side (prefers `og:title`, falls back to `<title>`), so the
+  Shortcut only sends the URL and description.


### PR DESCRIPTION
Lets me add a `reading` (or `building`) item from an Apple Shortcut: send a URL + description, and it opens a draft PR with the post already written.

**Flow:** Shortcut → GitHub API (`workflow_dispatch`) → Actions fetches the page title, writes the post, opens a **draft PR**.

**Added:**
- `.github/workflows/add-stream-item.yml` — dispatch workflow (inputs: url, description, type), opens a draft PR via `peter-evans/create-pull-request`
- `scripts/new-stream-item.mjs` — dependency-free; fetches `og:title`/`<title>`, writes the markdown in the existing post format
- `scripts/stream-item-shortcut.md` — setup instructions (fine-grained PAT with only `actions:write`, the repo "allow Actions to create PRs" setting, and the Shortcut actions)
- `eslint.config.mjs` — treat `.mjs` as ES modules

Verified the script locally against a real URL — it fetched the title and wrote a correctly-formatted post. The workflow only runs on manual dispatch, so merging is safe; it needs the one-time PAT + repo-setting setup (in the doc) before the Shortcut can use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)