### PR TITLE
Add optional title input to stream-item workflow

### DIFF
--- a/.github/workflows/add-stream-item.yml
+++ b/.github/workflows/add-stream-item.yml
@@ -13,6 +13,10 @@ on:
         description: Short take / description
         required: false
         default: ''
+      title:
+        description: Title (optional; detected from the page if omitted)
+        required: false
+        default: ''
       type:
         description: reading or building
         required: false
@@ -37,6 +41,7 @@ jobs:
         env:
           URL: ${{ inputs.url }}
           DESCRIPTION: ${{ inputs.description }}
+          TITLE: ${{ inputs.title }}
           TYPE: ${{ inputs.type }}
         run: node scripts/new-stream-item.mjs
 

--- a/scripts/new-stream-item.mjs
+++ b/scripts/new-stream-item.mjs
@@ -12,6 +12,7 @@ import path from 'node:path';
 const url = (process.env.URL || '').trim();
 const description = (process.env.DESCRIPTION || '').trim();
 const type = (process.env.TYPE || 'reading').trim();
+const providedTitle = (process.env.TITLE || '').trim();
 
 if (!url) {
   console.error('URL is required (set the URL env var).');
@@ -64,7 +65,8 @@ function yamlQuote(s) {
   return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
 }
 
-const title = await fetchTitle(url);
+// Use the supplied title if given, otherwise detect it from the page.
+const title = providedTitle || (await fetchTitle(url));
 
 const now = new Date();
 const yyyy = String(now.getFullYear());

--- a/scripts/stream-item-shortcut.md
+++ b/scripts/stream-item-shortcut.md
@@ -40,6 +40,8 @@ Make a new Shortcut with these actions:
        - `url` (Text): the Shortcut Input / URL from step 1
        - `description` (Text): the answer from step 2
        - `type` (Text): `reading`
+       - `title` (Text, optional): leave empty to use the page's detected title,
+         or pass your own to override it
 4. (Optional) **Show Notification**: "Reading item submitted".
 
 A successful dispatch returns `204 No Content`. The workflow then runs and opens a draft


### PR DESCRIPTION
Adds an optional `title` input to the `add-stream-item` workflow.

- If `title` is provided, it's used as-is (and the page fetch is skipped).
- If omitted, the title is detected from the page as before.

Verified both paths locally. The Shortcut doc is updated to note the optional field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)