### PR TITLE
Add shouldPublish input (auto-merge instead of draft)

### DIFF
--- a/.github/workflows/add-stream-item.yml
+++ b/.github/workflows/add-stream-item.yml
@@ -21,6 +21,11 @@ on:
         description: reading or building
         required: false
         default: reading
+      shouldPublish:
+        description: Publish immediately (merge the PR) instead of opening a draft
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -43,13 +48,15 @@ jobs:
           DESCRIPTION: ${{ inputs.description }}
           TITLE: ${{ inputs.title }}
           TYPE: ${{ inputs.type }}
+          SHOULD_PUBLISH: ${{ inputs.shouldPublish }}
         run: node scripts/new-stream-item.mjs
 
-      - name: Open draft PR
+      - name: Open PR
+        id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
           branch: ${{ steps.create.outputs.branch }}
-          draft: true
+          draft: ${{ steps.create.outputs.publish != 'true' }}
           title: 'Add ${{ inputs.type }}: ${{ steps.create.outputs.title }}'
           commit-message: 'Add ${{ inputs.type }} item: ${{ steps.create.outputs.title }}'
           add-paths: content/posts/**
@@ -60,3 +67,9 @@ jobs:
             - File: `${{ steps.create.outputs.path }}`
 
             Edit the wording if you want, then mark it ready and merge.
+
+      - name: Publish (merge) if requested
+        if: ${{ steps.create.outputs.publish == 'true' && steps.cpr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch

--- a/scripts/new-stream-item.mjs
+++ b/scripts/new-stream-item.mjs
@@ -13,6 +13,8 @@ const url = (process.env.URL || '').trim();
 const description = (process.env.DESCRIPTION || '').trim();
 const type = (process.env.TYPE || 'reading').trim();
 const providedTitle = (process.env.TITLE || '').trim();
+// Accept a boolean either as a real boolean or a "true"/"1"/"yes" string.
+const shouldPublish = /^(true|1|yes)$/i.test((process.env.SHOULD_PUBLISH || '').trim());
 
 if (!url) {
   console.error('URL is required (set the URL env var).');
@@ -105,6 +107,6 @@ if (process.env.GITHUB_OUTPUT) {
   const branch = `${type}-${dateStr}-${slug}`.slice(0, 80);
   await appendFile(
     process.env.GITHUB_OUTPUT,
-    `title=${title}\npath=${filepath}\nbranch=${branch}\nslug=${slug}\n`
+    `title=${title}\npath=${filepath}\nbranch=${branch}\nslug=${slug}\npublish=${shouldPublish}\n`
   );
 }

--- a/scripts/stream-item-shortcut.md
+++ b/scripts/stream-item-shortcut.md
@@ -42,6 +42,8 @@ Make a new Shortcut with these actions:
        - `type` (Text): `reading`
        - `title` (Text, optional): leave empty to use the page's detected title,
          or pass your own to override it
+       - `shouldPublish` (Boolean, optional): `true` merges the PR straight away
+         (publishes), anything else opens a draft to review first
 4. (Optional) **Show Notification**: "Reading item submitted".
 
 A successful dispatch returns `204 No Content`. The workflow then runs and opens a draft


### PR DESCRIPTION
Adds a `shouldPublish` boolean input to the `add-stream-item` workflow.

- **`shouldPublish: true`** → opens a normal (non-draft) PR and merges it immediately (squash + delete branch), so the item publishes right away.
- **omitted / false** → opens a draft to review first, as before.

The script normalizes the flag (accepts a real boolean or `"true"`/`"1"`/`"yes"`) and emits it as a step output, so it behaves consistently however the Shortcut sends it.

If the immediate merge can't proceed for some reason, it degrades gracefully to a normal open PR you can merge by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)