### PR TITLE
Link reading/building posts to their external URL

### DIFF
--- a/content/_includes/layouts/post.njk
+++ b/content/_includes/layouts/post.njk
@@ -11,9 +11,26 @@ layout: base
   {% include "partials/post/image.njk" %}
 
   <header>
+    {%- if type -%}
+    <p class="post-type post-type--{{ type }}">
+      {%- if type == "reading" -%}📚 Reading
+      {%- elif type == "building" -%}🔨 Building
+      {%- else -%}{{ type | capitalize }}
+      {%- endif -%}
+    </p>
+    {%- endif -%}
+    {%- if externalUrl -%}
+    <h1 class="external-post"><a href="{{ externalUrl }}" target="_blank" rel="noopener noreferrer">
+      {%- if type == "reading" -%}<em>&ldquo;{{ title }}&rdquo;</em>{%- else -%}{{ title }}{%- endif -%}
+      <span class="external-arrow" aria-hidden="true"> ↗</span></a></h1>
+    {%- else -%}
     <h1>{{ title }}</h1>
+    {%- endif -%}
   </header>
   {% include "partials/post/top-meta.njk" %}
+  {%- if externalUrl -%}
+  <p class="external-link"><a href="{{ externalUrl }}" target="_blank" rel="noopener noreferrer">{{ externalUrl | replace("https://", "") | replace("http://", "") }} ↗</a></p>
+  {%- endif -%}
   {% include "disclaimers/disclaimer.njk" %}
   {{ content | safe }}
 </article>

--- a/content/_includes/partials/feeds/json/item-meta.njk
+++ b/content/_includes/partials/feeds/json/item-meta.njk
@@ -1,5 +1,8 @@
 "id": "{{ absolutePostUrl }}",
-"url": "{{ absolutePostUrl }}",
+"url": "{{ entryUrl }}",
+{%- if post.data.externalUrl %}
+"external_url": "{{ post.data.externalUrl }}",
+{%- endif %}
 "title": "{{ post.data.title }}",
 "date_published": "{{ post.date | dateToRfc3339 }}",
 "language": "{{ siteConfig.language }}",

--- a/content/_includes/partials/feeds/rss/entry-meta.njk
+++ b/content/_includes/partials/feeds/rss/entry-meta.njk
@@ -1,4 +1,4 @@
 <title>{{ post.data.title }}</title>
-<link href="{{ absolutePostUrl }}"/>
+<link href="{{ entryUrl }}"/>
 <updated>{{ post.date | dateToRfc3339 }}</updated>
 <id>{{ absolutePostUrl }}</id>

--- a/content/utils/feeds/json/excerpts.njk
+++ b/content/utils/feeds/json/excerpts.njk
@@ -12,6 +12,7 @@ eleventyExcludeFromCollections: true
   "items": [
     {%- for post in collections.publishedPosts|limit(itemLimit) %}
     {%- set absolutePostUrl %}{{ post.url | alwaysProductionUrl }}{% endset -%}
+    {%- set entryUrl = post.data.externalUrl or absolutePostUrl -%}
     {
       {%- include "partials/feeds/json/item-meta.njk" -%}
       "content_html": "{%- include "partials/feeds/disclaimer.njk" -%}&lt;p&gt;{%- excerpt post %}&lt;/p&gt;{%- include "partials/feeds/keep-reading.njk" -%}"

--- a/content/utils/feeds/json/full.njk
+++ b/content/utils/feeds/json/full.njk
@@ -12,6 +12,7 @@ eleventyExcludeFromCollections: true
   "items": [
     {%- for post in collections.publishedPosts|limit(itemLimit) -%}
     {%- set absolutePostUrl %}{{ post.url | alwaysProductionUrl }}{% endset -%}
+    {%- set entryUrl = post.data.externalUrl or absolutePostUrl -%}
     {
       {%- include "partials/feeds/json/item-meta.njk" -%}
       "content_html": "{%- include "partials/feeds/disclaimer.njk" -%}{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}"

--- a/content/utils/feeds/rss/excerpts.njk
+++ b/content/utils/feeds/rss/excerpts.njk
@@ -10,6 +10,7 @@ eleventyExcludeFromCollections: true
 {%- include "partials/feeds/rss/feed-meta.njk" %}
 {%- for post in collections.publishedPosts|limit(postLimit) -%}
 {%- set absolutePostUrl -%}{{ post.url | alwaysProductionUrl }}{%- endset -%}
+{%- set entryUrl = post.data.externalUrl or absolutePostUrl -%}
 <entry>
 {%- include "partials/feeds/rss/entry-meta.njk" -%}
 <content type="html">

--- a/content/utils/feeds/rss/full.njk
+++ b/content/utils/feeds/rss/full.njk
@@ -10,6 +10,7 @@ eleventyExcludeFromCollections: true
 {%- include "partials/feeds/rss/feed-meta.njk" -%}
 {%- for post in collections.publishedPosts|limit(postLimit) -%}
 {%- set absolutePostUrl -%}{{ post.url | alwaysProductionUrl }}{%- endset -%}
+{%- set entryUrl = post.data.externalUrl or absolutePostUrl -%}
 {%- set content = post.templateContent -%}
 <entry>
 {%- include "partials/feeds/rss/entry-meta.njk" -%}

--- a/src/styles/partials/_post.scss
+++ b/src/styles/partials/_post.scss
@@ -5,3 +5,4 @@
 @use 'post/navigation';
 @use 'post/bottom_meta';
 @use 'post/scroll_up_arrow';
+@use 'post/external';

--- a/src/styles/partials/post/_external.scss
+++ b/src/styles/partials/post/_external.scss
@@ -1,0 +1,32 @@
+// Styling for reading / building (external link) post pages.
+.single-article {
+  .post-type {
+    margin: 0 0 0.5rem;
+    font-size: 0.8125rem;
+    font-family: var(--arial-font-family);
+    letter-spacing: 0.03rem;
+    text-transform: uppercase;
+    color: var(--post-meta-color);
+  }
+
+  h1.external-post a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  .external-arrow {
+    font-size: 0.7em;
+    color: var(--post-meta-color);
+  }
+
+  .external-link {
+    font-family: var(--arial-font-family);
+    font-size: 0.95rem;
+    word-break: break-word;
+  }
+}


### PR DESCRIPTION
Fixes the dead-end where a reading/building item's page (and its feed entry) pointed at an internal page with no link out.

**Post page** (items with `externalUrl`): now shows the 📚/🔨 type label, links the title straight to the source (italicised + quoted for reading items), and displays the external URL. Regular posts are unchanged.

**Feeds** (Atom + JSON): each entry's `link`/`url` points at the external URL when present, while the internal permalink stays as the stable `id` (JSON also gets a proper `external_url`).

Verified: post pages render correctly, regular posts unaffected, both XML feeds pass `xmllint`, JSON is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)