### PR TITLE
Namespace reading/building permalinks

### DIFF
--- a/content/posts/posts.json
+++ b/content/posts/posts.json
@@ -3,7 +3,7 @@
   "tags": [
     "post"
   ],
-  "permalink": "{% if customPermalink %}{{ customPermalink }}{% else %}/{{ title | slugify }}/{% endif %}",
+  "permalink": "{% if customPermalink %}{{ customPermalink }}{% elif type == 'reading' %}/reading/{{ title | slugify }}/{% elif type == 'building' %}/building/{{ title | slugify }}/{% else %}/{{ title | slugify }}/{% endif %}",
   "language": "en",
   "published": true,
   "ogType": "article",


### PR DESCRIPTION
- Reading posts → `/reading/<slug>/`
- Building posts → `/building/<slug>/`
- Everything else (and anything with a `customPermalink`) → `/<slug>/` as before

One data-driven change in `content/posts/posts.json`. Verified the build puts each type in the right place and leaves regular posts at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)