### PR TITLE
Add type-filter sub-nav and section pages

### DIFF
--- a/_11ty/collections/buildingPosts.js
+++ b/_11ty/collections/buildingPosts.js
@@ -1,0 +1,12 @@
+const moduleName = require('../helpers/moduleName');
+const { POST_COLLECTION_TAG_NAME } = require('../constants');
+
+// Building posts (side projects / repos), newest first.
+module.exports = {
+  name: moduleName(__filename),
+  body: (collectionApi) =>
+    collectionApi
+      .getFilteredByTag(POST_COLLECTION_TAG_NAME)
+      .reverse()
+      .filter((item) => item.data.published && item.data.type === 'building'),
+};

--- a/_11ty/collections/readingPosts.js
+++ b/_11ty/collections/readingPosts.js
@@ -1,0 +1,12 @@
+const moduleName = require('../helpers/moduleName');
+const { POST_COLLECTION_TAG_NAME } = require('../constants');
+
+// Reading posts (external link items), newest first.
+module.exports = {
+  name: moduleName(__filename),
+  body: (collectionApi) =>
+    collectionApi
+      .getFilteredByTag(POST_COLLECTION_TAG_NAME)
+      .reverse()
+      .filter((item) => item.data.published && item.data.type === 'reading'),
+};

--- a/_11ty/layoutAliases.js
+++ b/_11ty/layoutAliases.js
@@ -1,5 +1,6 @@
 module.exports = {
   base: 'layouts/base.njk',
+  'post-list': 'layouts/post-list.njk',
   page: 'layouts/page.njk',
   post: 'layouts/post.njk',
   project: 'layouts/project.njk',

--- a/content/_includes/layouts/post-list.njk
+++ b/content/_includes/layouts/post-list.njk
@@ -1,0 +1,24 @@
+---
+layout: base
+---
+
+{% include "partials/stream-subnav.njk" %}
+
+<div class="post-list">
+  <ul class="no-bullets">
+  {% for post in pagination.items %}
+    <li>
+      {% include "partials/single-post-excerpt.njk" %}
+    </li>
+  {% endfor %}
+  </ul>
+</div>
+
+{% include "partials/scroll-up-arrow.njk" %}
+
+{%- set totalPages = pagination.pages|length -%}
+{%- set currentPage = pagination.pageNumber + 1 -%}
+{%- set previousHref = pagination.href.previous -%}
+{%- set nextHref = pagination.href.next -%}
+
+{% include "partials/pagination.njk" %}

--- a/content/_includes/partials/stream-subnav.njk
+++ b/content/_includes/partials/stream-subnav.njk
@@ -1,0 +1,13 @@
+{%- set subnavItems = [
+  { label: "All", url: "/blog/" },
+  { label: "Writing", url: "/writing/" },
+  { label: "Reading", url: "/reading/" },
+  { label: "Building", url: "/building/" }
+] -%}
+<nav class="stream-subnav" aria-label="Filter posts by type">
+  <ul>
+  {%- for item in subnavItems %}
+    <li{% if item.url in page.url %} class="active" aria-current="page"{% endif %}><a href="{{ item.url }}">{{ item.label }}</a></li>
+  {%- endfor %}
+  </ul>
+</nav>

--- a/content/pages/blog.njk
+++ b/content/pages/blog.njk
@@ -1,31 +1,11 @@
 ---
-layout: base
+layout: post-list
 title: Blog
 pagination:
   data: collections.publishedPosts
   size: 10
-  alias: posts
 eleventyNavigation:
   key: Blog
   order: 1
 permalink: "/blog{% if pagination.pageNumber > 0 %}/{{ pagination.pageNumber + 1 }}{% endif %}/index.html"
 ---
-
-<div class="post-list">
-  <ul class="no-bullets">
-  {% for post in posts %}
-    <li>
-      {% include "partials/single-post-excerpt.njk" %}
-    </li>
-  {% endfor %}
-  </ul>
-</div>
-
-{% include "partials/scroll-up-arrow.njk" %}
-
-{%- set totalPages = pagination.pages|length -%}
-{%- set currentPage = pagination.pageNumber + 1 -%}
-{%- set previousHref = pagination.href.previous -%}
-{%- set nextHref = pagination.href.next -%}
-
-{% include "partials/pagination.njk" %}

--- a/content/pages/building.njk
+++ b/content/pages/building.njk
@@ -1,0 +1,10 @@
+---
+layout: post-list
+title: Building
+pagination:
+  data: collections.buildingPosts
+  size: 10
+eleventyNavigation:
+  parent: Blog
+permalink: "/building{% if pagination.pageNumber > 0 %}/{{ pagination.pageNumber + 1 }}{% endif %}/index.html"
+---

--- a/content/pages/reading.njk
+++ b/content/pages/reading.njk
@@ -1,0 +1,10 @@
+---
+layout: post-list
+title: Reading
+pagination:
+  data: collections.readingPosts
+  size: 10
+eleventyNavigation:
+  parent: Blog
+permalink: "/reading{% if pagination.pageNumber > 0 %}/{{ pagination.pageNumber + 1 }}{% endif %}/index.html"
+---

--- a/content/pages/writing.njk
+++ b/content/pages/writing.njk
@@ -1,0 +1,10 @@
+---
+layout: post-list
+title: Writing
+pagination:
+  data: collections.writingPosts
+  size: 10
+eleventyNavigation:
+  parent: Blog
+permalink: "/writing{% if pagination.pageNumber > 0 %}/{{ pagination.pageNumber + 1 }}{% endif %}/index.html"
+---

--- a/src/styles/pages/_index.scss
+++ b/src/styles/pages/_index.scss
@@ -133,3 +133,35 @@
     color: var(--post-meta-color);
   }
 }
+
+// Horizontal filter sub-nav at the top of the blog / type listing pages.
+// Matches the main nav: default link colour, active item underlined via a
+// bottom border. Just a little smaller.
+.stream-subnav {
+  margin-bottom: 1.5rem;
+  font-family: var(--arial-font-family);
+  font-size: 0.875rem;
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+  }
+
+  li {
+    line-height: 1;
+    padding-bottom: 0.35rem;
+    border-bottom: 2px solid transparent;
+
+    &.active {
+      border-bottom-color: var(--link-color);
+    }
+  }
+
+  a {
+    text-decoration: none;
+  }
+}


### PR DESCRIPTION
Adds a way to browse the stream by type.

- **Blog** now has a horizontal sub-nav: **All · Writing · Reading · Building** (styled like the main nav).
- **Writing** (`/writing/`), **Reading** (`/reading/`), **Building** (`/building/`) are their own paginated listing pages, each filtered to that type.
- The top nav (Blog · Archive · Subscribe) is unchanged; the section pages sit under Blog so it stays highlighted.

All four listing pages share a new `post-list` layout, so the sub-nav + list + pagination markup lives in one place instead of being duplicated per page. New `readingPosts` / `buildingPosts` collections back the filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)